### PR TITLE
Grab PATH on plugin initialization

### DIFF
--- a/messages.json
+++ b/messages.json
@@ -5,5 +5,6 @@
   "0.4.0": "sublime-messages/v0.4.0.txt",
   "0.5.0": "sublime-messages/v0.5.0.txt",
   "0.6.0": "sublime-messages/v0.6.0.txt",
-  "0.7.0": "sublime-messages/v0.7.0.txt"
+  "0.7.0": "sublime-messages/v0.7.0.txt",
+  "0.7.2": "sublime-messages/v0.7.2.txt"
 }

--- a/sublime-messages/v0.7.2.txt
+++ b/sublime-messages/v0.7.2.txt
@@ -1,0 +1,6 @@
+Version 0.7.2 makes the plugin better at finding your `PATH` environment
+variable. If you have changed the "exectuable" setting to work around not finding
+`node` or `importjs`, you might be able to remove that workaround now.
+
+As always, you should also update the import-js binary by running
+`npm install -g import-js`


### PR DESCRIPTION
I've started using nodenv recently. When I did, the Sublime import-js
plugin stopped working. This is because the `node` executable is no
longer available in /usr/local/bin. To fix this, we need to grab the
PATH environment variable from the user's shell (which should contain
the folder where `node` is available. )

I've shamelessly copied the approach that the SublimeLinter 3 plugin
uses ([1](https://github.com/SublimeLinter/SublimeLinter3/blob/88578d6256652862f900bc342f51f74c161f646e/lint/util.py)). I simplified it however to only support posix systems and
(probably) also only bash and zsh. The technique involves executing a
command using the user's shell `echo`ing the $PATH variable. We can then
use that when we later execute `importjs`. The PATH extraction is only
run on plugin initialization (`plugin_loaded` [2](https://www.sublimetext.com/docs/3/api_reference.html)).

Fixes #2
