### PR TITLE
Replace buffer before asking to resolve

### DIFF
--- a/import-js.py
+++ b/import-js.py
@@ -136,6 +136,8 @@ class ImportJsCommand(sublime_plugin.TextCommand):
                 args['command'] = 'add'
                 args['imports'] = resolved_imports
                 self.run(edit, **args)
+            self.view.run_command("import_js_replace",
+                                  {"characters": result.get('fileContent')})
             self.ask_to_resolve(result.get('unresolvedImports'),
                                 handle_resolved_imports)
             return


### PR DESCRIPTION
To reproduce:
1. Run fix imports on a file that has multiple words to import--some
   which have exact matches and some which need prompts
2. Select matches from all prompts
3. Examine buffer

I would expect to see all of the missing imports to be imported.
Instead, I only see the ones that were prompted for. Running fix imports
a second time seems to get the rest.

I fixed this by running the replace command before asking to resolve.
This will make sure that all things get updated properly.

Fixes #5
