### PR TITLE
Replaced `exectutible` option with `paths` option

### DIFF
--- a/ImportJS.sublime-settings
+++ b/ImportJS.sublime-settings
@@ -1,3 +1,3 @@
 {
-  "executable": "importjs"
+  "paths": []
 }

--- a/README.md
+++ b/README.md
@@ -48,12 +48,11 @@ zsh (Linux)    | ~/.zshenv or ~/.zprofile
 fish           | ~/.config/fish/config.fish
 
 Alternatively, you can also try editing the ImportJS User Settings from the
-Preferences > Package Settings > ImportJS > Settings — User menu and set the
-`executable` option to point to the path to the `importjs` executable. Example:
+Preferences > Package Settings > ImportJS > Settings — User menu and add the folder where the `importjs` executable is located to the `paths` option. Example:
 
 ```json
 {
-  "executable": "/Users/USERNAME/.nvm/versions/node/v4.4.3/bin/importjs"
+  "paths": ["/Users/USERNAME/.nvm/versions/node/v4.4.3/bin"]
 }
 ```
 

--- a/import-js.py
+++ b/import-js.py
@@ -39,8 +39,15 @@ def plugin_loaded():
         'LANG': 'en_US.UTF-8',
     })
 
+    path_env_variable = extract_path()
+
+    settings = sublime.load_settings('ImportJS.sublime-settings')
+    setting_paths = settings.get('paths')
+    if setting_paths:
+        path_env_variable = ':'.join(setting_paths) + ':' + path_env_variable
+            
     import_js_environment.update({
-        'PATH': extract_path(),
+        'PATH': path_env_variable,
     })
 
     print('ImportJS loaded with environment:')
@@ -60,11 +67,11 @@ def no_executable_error(executable):
         tools is located in .bash_profile, .zprofile, or the equivalent file
         for your shell.
 
-        Alternatively, you might have to set a custom `executable` in your
+        Alternatively, you might have to set the `paths` option in your
         ImportJS package user settings. Example:
 
         {{
-            "executable": "/usr/local/bin/importjs"
+            "paths": ["/Users/USERNAME/.nvm/versions/node/v4.4.3/bin"]
         }}
 
         To see where importjs binary is located, run `which importjs`
@@ -84,9 +91,8 @@ class ImportJsCommand(sublime_plugin.TextCommand):
             sublime.Region(0, self.view.size()))
 
         project_root = self.view.window().extract_variables()['folder']
-        settings = sublime.load_settings('ImportJS.sublime-settings')
 
-        executable = settings.get('executable')
+        executable = 'importjs'
         cmd = args.get('command')
         command = [executable, cmd]
 


### PR DESCRIPTION
I am using this plugin on a computer where nodejs was installed via NVM. I tried setting the `exectutible` option in the sublime plugin settings, but I kept getting this error :

```
Error when executing importjs:
env: node: No such file or directory
```

This is because `node` was not defined in the path as well as `importjs` because I don't have a global install of node, rather it's only installed via NVM.

Specifying a set of paths to prepend to the PATH environment variable is more flexible and it's the method used by other sublime plugins (for example: SublimeLinter/SublimeLinter3)
